### PR TITLE
Dt 969 retire poll pusher and offender search 

### DIFF
--- a/offender-pollpush/locals.tf
+++ b/offender-pollpush/locals.tf
@@ -9,5 +9,5 @@ locals {
     "${data.terraform_remote_state.vpc.vpc_private-subnet-az3}",
   ]
 
-  desired_count = "${var.offenderpollpush_conf.desired_count}"
+  desired_count = "${var.offenderpollpush_conf["desired_count"]}"
 }

--- a/offender-pollpush/locals.tf
+++ b/offender-pollpush/locals.tf
@@ -8,4 +8,6 @@ locals {
     "${data.terraform_remote_state.vpc.vpc_private-subnet-az2}",
     "${data.terraform_remote_state.vpc.vpc_private-subnet-az3}",
   ]
+
+  desired_count = "${var.offenderpollpush_conf.desired_count}"
 }

--- a/offender-pollpush/offender-pollpush.tf
+++ b/offender-pollpush/offender-pollpush.tf
@@ -86,7 +86,7 @@ resource "aws_ecs_service" "offenderpoll_service" {
     security_groups = ["${aws_security_group.offenderpoll_sg.id}"]
   }
   # Not horizontally scalable - single instance
-  desired_count = 1
+  desired_count = "${local.desired_count}"
   depends_on    = ["aws_iam_role.offenderpollpush_task_role"]
   service_registries {
     registry_arn   = "${aws_service_discovery_service.offenderpoll_svc_record.arn}"

--- a/offender-pollpush/offender-pollpush.tf
+++ b/offender-pollpush/offender-pollpush.tf
@@ -92,9 +92,6 @@ resource "aws_ecs_service" "offenderpoll_service" {
     registry_arn   = "${aws_service_discovery_service.offenderpoll_svc_record.arn}"
     container_name = "offenderpollpush"
   }
-  lifecycle {
-    ignore_changes = ["desired_count"]
-  }
 }
 
 # Create a service record in the ecs cluster's private namespace

--- a/offender-pollpush/variables.tf
+++ b/offender-pollpush/variables.tf
@@ -66,6 +66,8 @@ variable "offenderpollpush_conf" {
     env_process_page_size               = "10"
     env_poll_seconds                    = "60"
     env_sns_region                      = "eu-west-2"
+
+    desired_count                       = 1
   }
 }
 

--- a/offender-pollpush/variables.tf
+++ b/offender-pollpush/variables.tf
@@ -67,7 +67,7 @@ variable "offenderpollpush_conf" {
     env_poll_seconds                    = "60"
     env_sns_region                      = "eu-west-2"
 
-    desired_count                       = 1
+    desired_count                       = "1"
   }
 }
 

--- a/offender-search/variables.tf
+++ b/offender-search/variables.tf
@@ -64,8 +64,8 @@ variable "offendersearch_conf" {
     memory        = "2048"
 
     # ECS Task App Autoscaling min and max thresholds
-    ecs_scaling_min_capacity = 1
-    ecs_scaling_max_capacity = 5
+    ecs_scaling_min_capacity = 0
+    ecs_scaling_max_capacity = 0
 
     # ECS Task App AutoScaling will kick in above avg cpu util set here
     ecs_target_cpu = "60"


### PR DESCRIPTION
By default offender search is off everywhere, whereas by default poll pusher is off in test/preprod/prod

* Poll pushers uses a set desired count
* Offender search uses a scaling count so methods to set to zero are slightly different 